### PR TITLE
model の validation テストの実装

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --require rails_helper
 --format documentation
+--color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,36 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: 2.7
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/ExpectInHook:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 5
+
+Metrics/AbcSize:
+  # The ABC size is a calculated magnitude, so this number can be a Fixnum or
+  # a Float.
+  Max: 30

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -19,4 +19,6 @@
 #
 class Article < ApplicationRecord
   belongs_to :user
+  validates :title, presence: true, length: { maximum: 50 }
+  validates :body, presence: true
 end

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -21,4 +21,6 @@
 class ArticleLike < ApplicationRecord
   belongs_to :user
   belongs_to :article
+  validates :user_id, presence: true
+  validates :article_id, presence: true
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,4 +22,5 @@
 class Comment < ApplicationRecord
   belongs_to :article
   belongs_to :user
+  validates :body, presence: true, length: { maximum: 250 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,4 +41,5 @@ class User < ApplicationRecord
   has_many :artiles, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -71,3 +71,6 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+# context ごとに let! を使い分けたい場合があるため無効に
+RSpec/LetSetup:
+  Enabled: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2021_04_28_012424) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+    t.index ["name"], name: 'index', unique: true
   end
 
   add_foreign_key "article_likes", "articles"

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :article_like do
+    user
+    article
+  end
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :article do
+    title { Faker::Lorem.word }
+    body { Faker::Lorem.sentence }
+    user
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    body { Faker::Lorem.sentence }
+    user
+    article
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Name.name }
+    password { Faker::Internet.password }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
+  end
+end

--- a/spec/models/article_like_spec.rb
+++ b/spec/models/article_like_spec.rb
@@ -21,5 +21,32 @@
 require "rails_helper"
 
 RSpec.describe ArticleLike, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "ユーザーと記事の id が存在するとき" do
+    let(:article) { create(:article) }
+    let(:user) { create(:user) }
+    let(:article_like) { build(:article_like, user_id: user.id, article_id: article.id) }
+    it "いいねできる" do
+      expect(article_like).to be_valid
+    end
+  end
+
+  context "ユーザーid が存在しない時" do
+    let(:article) { create(:article) }
+    let(:article_like) { build(:article_like, user_id: nil, article_id: article.id) }
+    it "いいねできない" do
+      expect(article_like).to be_invalid
+      expect(article_like.errors[:user]).to eq ["must exist"]
+      expect(article_like.errors[:user_id]).to eq ["can't be blank"]
+    end
+  end
+
+  context "記事の id が存在しないとき" do
+    let(:user) { create(:user) }
+    let(:article_like) { build(:article_like, user_id: user.id, article_id: nil) }
+    it "いいねできない" do
+      expect(article_like).to be_invalid
+      expect(article_like.errors[:article]).to eq ["must exist"]
+      expect(article_like.errors[:article_id]).to eq ["can't be blank"]
+    end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -20,5 +20,38 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "必要な情報が揃っている時" do
+    let(:user) { build(:user) }
+    let(:article) { build(:article, user: user) }
+    it "機材の作成に成功する" do
+      expect(article).to be_valid
+    end
+  end
+
+  context "body が入力されていない時" do
+    let(:user) { build(:user) }
+    let(:article) { build(:article, user: user, body: nil) }
+    it "記事の作成に失敗する" do
+      expect(article).to be_invalid
+      expect(article.errors.details[:body][0][:error]).to eq :blank
+    end
+  end
+
+  context "title が入力されていないとき" do
+    let(:user) { build(:user) }
+    let(:article) { build(:article, user: user, title: nil) }
+    it "記事の作成に失敗する" do
+      expect(article).to be_invalid
+      expect(article.errors.details[:title][0][:error]).to eq :blank
+    end
+  end
+
+  context "title が51文字以上の時" do
+    let(:user) { build(:user) }
+    let(:article) { build(:article, user: user, title: "a" * 51) }
+    it "記事の作成に失敗する" do
+      expect(article).to be_invalid
+      expect(article.errors.messages[:title]).to eq ["is too long (maximum is 50 characters)"]
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -22,5 +22,32 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "コメントのbody が入力されている時" do
+    let(:user) { build(:user) }
+    let(:article) { build(:article, user: user) }
+    let(:comment) { build(:comment, article: article) }
+    it "コメントの投稿ができる" do
+      expect(comment).to be_valid
+    end
+  end
+
+  context "コメントのbody が入力されていない時" do
+    let(:user) { build(:user) }
+    let(:article) { build(:article, user: user) }
+    let(:comment) { build(:comment, article: article, body: nil) }
+    it "コメントの投稿に失敗する" do
+      expect(comment).to be_invalid
+      expect(comment.errors.messages[:body]).to eq ["can't be blank"]
+    end
+  end
+
+  context "コメントの文字数が251文字以上の時" do
+    let(:user) { build(:user) }
+    let(:article) { build(:article, user: user) }
+    let(:comment) { build(:comment, article: article, body: "a" * 251) }
+    it "コメントの投稿に失敗する" do
+      expect(comment).to be_invalid
+      expect(comment.errors.messages[:body]).to eq ["is too long (maximum is 250 characters)"]
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  context "必要な情報が全て揃っている時" do
+    let(:user) { build(:user) }
+    it "ユーザーの作成に成功する" do
+      expect(user).to be_valid
+    end
+  end
+
+  context "name が入力されていないとき" do
+    let(:user) { build(:user, name: nil) }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+      expect(user.errors.details[:name][0][:error]).to eq :blank
+    end
+  end
+
+  context "name だけ入力されている時" do
+    let(:user) { build(:user, email: nil, password: nil) }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+      expect(user.errors.details[:password][0][:error]).to eq :blank
+      expect(user.errors.details[:email][0][:error]).to eq :blank
+    end
+  end
+
+  context "すでに同じ名前のユーザーが存在するとき" do
+    let(:user) { build(:user, name: "foo") }
+    it "ユーザーの作成に失敗する" do
+      create(:user, name: "foo")
+      expect(user).to be_invalid
+      expect(user.errors.details[:name][0][:error]).to eq :taken
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,9 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.before(:all) do
+    FactoryBot.reload
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
## 概要
 - 各モデルに必要なバリデーションがあれば追加してテストを実装する

## 内容
 - user モデルにバリデーション追加してテストを簡単に実装
> email, password に関するバリデーションは devise_token_auth のデフォルトを使用することとした
 - その他のモデルにもバリデーションを追加してテストを実装