### PR TITLE
記事に関するAPIのルーティングの実装

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for "User", at: "auth"
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for "User", at: "auth"
+      resources :articles
+    end
+  end
 end


### PR DESCRIPTION
## 概要
 - /api/v1/articles で CRUD 処理ができるような endpoint が生えるよう、routes.rb を修正

## 内容
 - `namespace` を使って api/v1 から始まるように設定
 - `resources` を使って article の複数のルーティングを設定