### PR TITLE
記事作成の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,9 +4,22 @@ module Api::V1
       articles = Article.all.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
+
     def show
       article = Article.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      # binding.pry
+      article = current_user.articles.create!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+    private
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  has_many :artiles, dependent: :destroy
+  has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   validates :name, presence: true, uniqueness: { case_sensitive: false }

--- a/bin/webpack
+++ b/bin/webpack
@@ -5,7 +5,7 @@ ENV["NODE_ENV"]  ||= "development"
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+                                           Pathname.new(__FILE__).realpath)
 
 require "bundler/setup"
 

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -5,7 +5,7 @@ ENV["NODE_ENV"]  ||= "development"
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+                                           Pathname.new(__FILE__).realpath)
 
 require "bundler/setup"
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,6 @@ module WonderfulEditor5
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::Articles" , type: :request do
+RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles" do
     subject { get(api_v1_articles_path) }
+
     let!(:article1) { create(:article, updated_at: 1.days.ago) }
     let!(:article2) { create(:article, updated_at: 2.days.ago) }
     let!(:article3) { create(:article) }
@@ -13,11 +14,13 @@ RSpec.describe "Api::V1::Articles" , type: :request do
       expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
       expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
   end
+
   describe "GET /api/v1/articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
+
     context "記事の id を指定した時" do
       let(:article_id) { article.id }
       let(:article) { create(:article) }
@@ -28,15 +31,42 @@ RSpec.describe "Api::V1::Articles" , type: :request do
         expect(res["title"]).to eq article.title
         expect(res["updated_at"]).to be_present
         expect(res["user"].keys).to eq ["id", "name", "email"]
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
     end
+
     context "存在しない記事の id を指定した時" do
       let(:article_id) { 100000 }
-      fit "記事のレコードが見つからない" do
-        expect{ subject }.to raise_error(ActiveRecord::RecordNotFound)
+      it "記事のレコードが見つからない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
 
+  describe "POST /api/v1/articles" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    context "適切なパラメータを送信した時" do
+      let(:params) { { article: attributes_for(:article) } }
+      let(:current_user) { create(:user) }
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+      it "記事が作成される" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(res["user"]["id"]).to eq current_user.id
+        expect(response).to have_http_status(200)
+      end
+    end
+    context "不適切なパラメータを送信した時" do
+      let(:params) { attributes_for(:article) }
+      let(:current_user) { create(:user) }
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      it "記事作成に失敗する" do
+        expect { subject }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
 - 記事の作成機能とテストを実装

## 内容
 - base_api_controller に current_user メソッドを定義
 - 記事の`create`アクションとテストを実装
 