### PR TITLE
 新規登録 API の実装

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  private
+
+    def sign_up_params
+      params.permit(:name, :email, :password, :password_confirmation)
+    end
+
+    def account_update_params
+      params.permit(:name, :email)
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
   has_many :articles, dependent: :destroy

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,12 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
-
+  config.headers_names = { 'access-token': "access-token" ,
+                           client: "client" ,
+                           expiry: "expiry" ,
+                           uid: "uid",
+                           'token-type': "token-type" }
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can
   # do so by enabling this flag. NOTE: This feature is highly experimental!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations",
+      }
       resources :articles
     end
   end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+
+end


### PR DESCRIPTION
## 概要
 - devise_token_auth を使って、トークン認証を使ったユーザー認証機能を実装する
 - nameカラムを既存メソッドに付与したいため、devise_token_authのメソッドをオーバーライドする
 - 新規登録時にレスポンスとして返される header情報 を設定する

## 内容
 - `bundle exec rails g controller api/v1/auth/registrations` コマンドでコントローラーの作成
 - registrations controller を修正
 - routes.rb の修正
 - config/initializers/devise_token_auth.rb　ファイルを認証時、レスポンスとして返す header 情報を設定する