### PR TITLE
Article model に下書き機能を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -21,4 +22,5 @@ class Article < ApplicationRecord
   belongs_to :user
   validates :title, presence: true, length: { maximum: 50 }
   validates :body, presence: true
+  enum status: { draft: "draft", published: "published" }
 end

--- a/db/migrate/20210503065646_add_status_to_articles.rb
+++ b/db/migrate/20210503065646_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_28_012424) do
+ActiveRecord::Schema.define(version: 2021_05_03_065646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2021_04_28_012424) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
@@ -65,7 +66,6 @@ ActiveRecord::Schema.define(version: 2021_04_28_012424) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
-    t.index ["name"], name: 'index', unique: true
   end
 
   add_foreign_key "article_likes", "articles"

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: article_likes
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_article_likes_on_article_id  (article_id)
+#  index_article_likes_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :article_like do
     user

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,7 +1,35 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  status     :string           default("draft")
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_articles_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word }
     body { Faker::Lorem.sentence }
     user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  article_id :bigint           not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_comments_on_article_id  (article_id)
+#  index_comments_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (article_id => articles.id)
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :comment do
     body { Faker::Lorem.sentence }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  image                  :string
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     name { Faker::Name.name }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -20,18 +21,34 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  context "必要な情報が揃っている時" do
-    let(:user) { build(:user) }
-    let(:article) { build(:article, user: user) }
-    it "機材の作成に成功する" do
+  context "必要なレコードが入力されている時" do
+    let(:article) { build(:article) }
+    it "下書き状態の記事が作成できる" do
       expect(article).to be_valid
+      expect(article.status).to eq "draft"
+    end
+  end
+
+  context "status が下書き状態のとき" do
+    let(:article) { build(:article, :draft) }
+    it "下書き状態の記事が作成できる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "draft"
+    end
+  end
+
+  context "status が公開状態のとき" do
+    let(:article) { build(:article, :published) }
+    it "公開状態の記事が作成できる" do
+      expect(article).to be_valid
+      expect(article.status).to eq "published"
     end
   end
 
   context "body が入力されていない時" do
     let(:user) { build(:user) }
     let(:article) { build(:article, user: user, body: nil) }
-    it "記事の作成に失敗する" do
+    it "記事が作成できない" do
       expect(article).to be_invalid
       expect(article.errors.details[:body][0][:error]).to eq :blank
     end
@@ -40,7 +57,7 @@ RSpec.describe Article, type: :model do
   context "title が入力されていないとき" do
     let(:user) { build(:user) }
     let(:article) { build(:article, user: user, title: nil) }
-    it "記事の作成に失敗する" do
+    it "記事が作成できない" do
       expect(article).to be_invalid
       expect(article.errors.details[:title][0][:error]).to eq :blank
     end
@@ -49,7 +66,7 @@ RSpec.describe Article, type: :model do
   context "title が51文字以上の時" do
     let(:user) { build(:user) }
     let(:article) { build(:article, user: user, title: "a" * 51) }
-    it "記事の作成に失敗する" do
+    it "記事が作成できない" do
       expect(article).to be_invalid
       expect(article.errors.messages[:title]).to eq ["is too long (maximum is 50 characters)"]
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  image                  :string
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe User, type: :model do


### PR DESCRIPTION
## 概要
 - 記事の下書きの状態と公開の状態の２つを作って、モデルのテストを修正する

## 内容
 - article model に enum を使って、記事の状態に関する記述を追加
 - テーブルにカラムを追加するため、migration ファイルを作成
 - 記事の Factory を修正
 - 記事の models spec を修正
