### PR TITLE
既存のAPIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,12 +2,12 @@ module Api::V1
   class ArticlesController < BaseApiController
     before_action :authenticate_user!, only: [:create, :update, :delete]
     def index
-      articles = Article.all.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
@@ -30,7 +30,7 @@ module Api::V1
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
-  attributes :id, :title, :updated_at
+  attributes :id, :title, :updated_at, :status
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -4,15 +4,17 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { create(:article, updated_at: 1.days.ago) }
-    let!(:article2) { create(:article, updated_at: 2.days.ago) }
-    let!(:article3) { create(:article) }
-    it "記事の一覧が取得できる" do
+    let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :published, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article, :published) }
+    let!(:article4) { create(:article, :draft) }
+    it "公開済みの記事の一覧が取得できる（更新順）" do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
       expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
-      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["status"]).to eq "published"
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "status", "user"]
       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
       expect(response).to have_http_status(:ok)
     end
@@ -21,17 +23,26 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "記事の id を指定した時" do
+    context "公開状態の記事の id を指定した時" do
       let(:article_id) { article.id }
-      let(:article) { create(:article) }
-      it "指定した記事のレコードが返ってくる" do
+      let(:article) { create(:article, :published) }
+      it "指定したidの公開記事のレコードが返ってくる" do
         subject
         res = JSON.parse(response.body)
         expect(res["id"]).to eq article.id
         expect(res["title"]).to eq article.title
         expect(res["updated_at"]).to be_present
+        expect(res["status"]).to eq "published"
         expect(res["user"].keys).to eq ["id", "name", "email"]
         expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "下書き状態の記事のidを指定した時" do
+      let(:article_id) { article.id }
+      let(:article) { create(:article) }
+      it "エラーする" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
@@ -50,9 +61,25 @@ RSpec.describe "Api::V1::Articles", type: :request do
       let(:params) { { article: attributes_for(:article) } }
       let(:current_user) { create(:user) }
       let(:headers) { current_user.create_new_auth_token }
-      it "記事が作成される" do
+      it "下書き記事が作成される" do
         expect { subject }.to change { Article.count }.by(1)
         res = JSON.parse(response.body)
+        expect(res["status"]).to eq "draft"
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(res["user"]["id"]).to eq current_user.id
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "記事の状態を公開に指定して適切なパラメータを送信したとき" do
+      let(:params) { { article: attributes_for(:article, :published) } }
+      let(:current_user) { create(:user) }
+      let(:headers) { current_user.create_new_auth_token }
+      it "公開記事が作成される" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "published"
         expect(res["title"]).to eq params[:article][:title]
         expect(res["body"]).to eq params[:article][:body]
         expect(res["user"]["id"]).to eq current_user.id
@@ -74,15 +101,27 @@ RSpec.describe "Api::V1::Articles", type: :request do
     subject { patch(api_v1_article_path(article_id), params: params, headers: headers) }
 
     let(:article_id) { article.id }
-    let(:article) { create(:article, user: current_user) }
-    let(:params) {  { article: { title: "foo", created_at: 1.days.ago } } }
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
+    let(:params) {  { article: { title: "foo", created_at: 1.days.ago, status: "published" } } }
+    context "下書き状態で自分の記事を更新しようとするとき" do
+      let!(:article) { create(:article, :draft, user: current_user) }
+      it "下書き状態で記事が更新できる" do
+        expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
+                              not_change { article.reload.body } &
+                              not_change { article.reload.created_at } &
+                              change { article.reload.status }.from(article.status).to(params[:article][:status])
+      end
+    end
 
-    it "適切な値だけ更新されている" do
-      expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
-                            not_change { article.reload.body } &
-                            not_change { article.reload.created_at }
+    context "他のユーザーの記事を更新しようとるすとき" do
+      let(:other_user) { create(:user) }
+      let!(:article) { create(:article, user: other_user) }
+
+      it "更新できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        change { Article.count }.by(0)
+      end
     end
   end
 


### PR DESCRIPTION
## 概要
 - 記事に状態を含めた内容を API とテストに反映する
 
## 内容
 - serializer を修正して、レスポンスに記事の状態を含める
 - 公開されている記事だけ取得できるように `index``show`メソッドを修正
 - 記事を作成・更新する時に、記事の公開/非公開を選択できるようにストロングパラメータに`status`を追加
 - 記事のAPIに関するテストを修正