### PR TITLE
下書き記事の一覧・詳細のAPI実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,14 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    before_action :authenticate_user!
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,11 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
+
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+    let!(:article1) { create(:article, :draft, user: current_user, updated_at: 1.days.ago)}
+    let!(:article2) { create(:article, :draft, user: current_user, updated_at: 2.days.ago)}
+    let!(:article3) { create(:article, :draft, user: current_user) }
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+    fit "自分が書いた下書き記事の一覧が取得できる（更新順）" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0]["status"]).to eq "draft"
+      expect(res[0]["user"]["id"]).to eq article1.user.id
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "status", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      expect(response).to have_http_status(:ok)
+    end
+  end
+  describe "GET /api/v1/articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+    let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) }
+    let(:article_id) { article.id }
+    context "自分が書いた下書き記事の id を指定した時" do
+      let(:article) { create(:article, :draft, user: current_user)}
+      fit "指定した下書き記事の詳細が取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["user"]["id"]).to eq article.user.id
+        expect(res["id"]).to eq article.id
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["status"]).to eq "draft"
+        expect(res["updated_at"]).to be_present
+        expect(res["user"].keys).to eq ["id", "name", "email"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+    context "他人が書いた下書き記事の id を指定した時" do
+      let(:article) { create(:article, :draft) }
+      fit "その記事の詳細を取得できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
 - 自分が書いた下書きの一覧と詳細を取得する API とテストの実装

## 内容
 - endpoint の設定・routes.rb の修正
 -- index: `/api/v1/articles/draft`
 -- show: `/api/v1/articles/draft/:id`
 - 下書き記事の一覧/詳細の APIを実装するコントローラーとリクエストスペックを作成して実装
