### PR TITLE
自分が書いた記事一覧の取得

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  class Current::ArticlesController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.published.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,18 +5,23 @@ Rails.application.routes.draw do
   get "sign_up", to: "home#index"
   get "sign_in", to: "home#index"
   get "articles/new", to: "home#index"
+  get "articles/draft", to: "home#index"
+  get "articles/drafts/:id/edit", to: "home#index"
+  get "articles/:id/edit", to: "home#index"
   get "articles/:id", to: "home#index"
+  get "mypage", to: "home#index"
 
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
-
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
-
+      namespace :current do
+        resources :articles, only: [:index]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+    let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) }
+    let!(:article1) { create(:article, :published, updated_at:1.days.ago, user: current_user) }
+    let!(:article2) { create(:article, :published, user: current_user) }
+    let!(:article3) { create(:article, :draft, user: current_user) }
+    let!(:article4) { create(:article, :published)}
+    fit "自分が書いた公開状態の記事の一覧が取得できる（更新順）" do
+      subject
+       res = JSON.parse(response.body)
+      expect(res.length).to eq 2
+      expect(res.map {|d| d["id"] }).to eq [article2.id, article1.id]
+      expect(res[0]["status"]).to eq "published"
+      expect(res[0]["user"]["id"]).to eq article1.user.id
+      expect(response).to have_http_status(:ok)
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "status", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+    end
+  end
+end


### PR DESCRIPTION
## 概要
 - 自分が書いた公開記事の一覧を取得する API とテストの実装

## 内容
 - endpoint を設定
 -- /api/v1/current/articles
 - apiとテストを実装する controller と spec ファイルを作成・実装