### PR TITLE
CORS の設定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "active_model_serializers", "~> 0.10.0"
 gem "bootsnap", ">= 1.4.2", require: false
 gem "devise_token_auth"
 gem "config"
+gem "rack-cors"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -324,6 +326,7 @@ DEPENDENCIES
   pry-doc
   pry-rails
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.0.3, >= 6.0.3.2)
   rails-erd
   rspec-rails

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,15 @@
+# Be sure to restart your server when you modify this file.
+
+ # Avoid CORS issues when API is called from the frontend app.
+ # Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
+
+ # Read more: https://github.com/cyu/rack-cors
+
+ Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins Settings.frontend.url
+    resource "*",
+             headers: :any,
+             methods: [:get, :post, :put, :patch, :delete, :options]
+  end
+end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+frontend:
+  url: "http://localhost:8080"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,2 @@
+frontend:
+  url: "http://localhost:8080"

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,5 +1,5 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+process.env.NODE_ENV = process.env.NODE_ENV || "development";
 
-const environment = require('./environment')
+const environment = require("./environment");
 
-module.exports = environment.toWebpackConfig()
+module.exports = environment.toWebpackConfig();


### PR DESCRIPTION
## 概要
 - フロントエンドからのアクセスを許可する為の設定

## 手順
1. #29 で導入した `Config` `で作成したファイルに定数を書き込む( `config/settings/development.yml` & `config/settings/test.yml` )
2. Gemfile に `rack-cors` を追記して `bundle install`
3. Cors の設定を追記

## 補足
 - Cors で設定したルールが雑で何でもオッケーになっているので、本来はしっかり絞りこむ必要があります。