### PR TITLE
トークンをレスポンスで返す際の設定が抜けていたので追加

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,6 +10,7 @@
     origins Settings.frontend.url
     resource "*",
              headers: :any,
+             expose: ["access-token", "expiry", "token-type", "uid", "client"],
              methods: [:get, :post, :put, :patch, :delete, :options]
   end
 end


### PR DESCRIPTION
## 概要
 - この設定をすることで response.headers に devise_token_auth を介したトークン情報がのって蹴ってきます。